### PR TITLE
Payara Microで動作確認するタスクを定義したbuild.gradleを追加しました。

### DIFF
--- a/doubleSubmit/build.gradle
+++ b/doubleSubmit/build.gradle
@@ -1,0 +1,55 @@
+apply plugin: 'java'
+apply plugin: 'war'
+
+tasks.withType(JavaCompile) {
+    sourceCompatibility = '1.8'
+    targetCompatibility = '1.8'
+    options.encoding = 'UTF-8'
+}
+
+repositories {
+    jcenter()
+    mavenCentral()
+}
+
+dependencies {
+    providedCompile 'javax:javaee-api:7.0'
+    archives 'fish.payara.extras:payara-micro:4.1.1.154'
+}
+
+sourceSets {
+    main {
+        java {
+            srcDir 'src/java'
+        }
+    }
+}
+
+war {
+    webAppDirName = 'web'
+    archiveName = 'doubleSubmit.war'
+}
+
+task copyMetaInfResources(type: Copy) {
+    from file('src/conf')
+    into new File(processResources.destinationDir, 'META-INF')
+}
+copyMetaInfResources.dependsOn processResources
+
+task rewritePersistenceXml << {
+    def file = new File(processResources.destinationDir, 'META-INF/persistence.xml')
+    def text = file.getText('UTF-8')
+    text = text.replaceAll('<jta-data-source>doubleSubmit</jta-data-source>', '<jta-data-source>jdbc/__default</jta-data-source>')
+    file.write(text, 'UTF-8')
+}
+rewritePersistenceXml.dependsOn copyMetaInfResources
+
+war.dependsOn rewritePersistenceXml
+
+task run(type:Exec) {
+    def payaraJar = configurations.archives.find { it.name ==~ /payara-micro.*/ }
+    def warFile = war.archivePath
+    commandLine 'java', '-jar', "$payaraJar", '--noCluster', '--deploy', "$warFile"
+}
+
+run.dependsOn war

--- a/doubleSubmit/build.gradle
+++ b/doubleSubmit/build.gradle
@@ -30,26 +30,36 @@ war {
     archiveName = 'doubleSubmit.war'
 }
 
+// src/confディレクトリの中身(persistence.xml)をWEB-INF/classes/META-INFにコピーする。
 task copyMetaInfResources(type: Copy) {
     from file('src/conf')
     into new File(processResources.destinationDir, 'META-INF')
 }
+// persistence.xmlのコピーはprocessResources(リソースのコピー)後に行う。
 copyMetaInfResources.dependsOn processResources
 
+// persistence.xmlを編集するタスク。
+// Payara MicroではDerbyがサーバーモードでは起動しないためデフォルトで用意されている
+// データソースを使う事にする。
+// そのため、このタスクで使用するデータソースのJNDI名を書き換えている。
 task rewritePersistenceXml << {
     def file = new File(processResources.destinationDir, 'META-INF/persistence.xml')
     def text = file.getText('UTF-8')
     text = text.replaceAll('<jta-data-source>doubleSubmit</jta-data-source>', '<jta-data-source>jdbc/__default</jta-data-source>')
     file.write(text, 'UTF-8')
 }
+// persistence.xmlの編集はWEB-INF/classes/META-INFへのコピー後に行う。
 rewritePersistenceXml.dependsOn copyMetaInfResources
 
+// WARファイルの作成はpersistence.xmlの編集後に行う。
 war.dependsOn rewritePersistenceXml
 
+// Payara Microで起動するタスク。
+// gradle runとすれば起動する。
 task run(type:Exec) {
+    // dependenciesでarchivesと指定したものから名前でpayara-microのJARファイルを探し出す。
     def payaraJar = configurations.archives.find { it.name ==~ /payara-micro.*/ }
     def warFile = war.archivePath
     commandLine 'java', '-jar', "$payaraJar", '--noCluster', '--deploy', "$warFile"
 }
-
 run.dependsOn war


### PR DESCRIPTION
次のコマンドでPayara Microがポート8080で起動します。

```
gradle run
```

READMEに書かれている通り http://localhost:8080/doubleSubmit/order にアクセスして動作確認が出来ます。