### PR TITLE
別スレッドの処理はManagedExecutorServiceを使うように変更しました

### DIFF
--- a/doubleSubmit/src/java/tokenexample/OrderServlet.java
+++ b/doubleSubmit/src/java/tokenexample/OrderServlet.java
@@ -11,6 +11,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import javax.annotation.Resource;
+import javax.enterprise.concurrent.ManagedExecutorService;
 import javax.inject.Inject;
 import javax.persistence.EntityManager;
 import javax.persistence.NoResultException;
@@ -32,6 +35,9 @@ public class OrderServlet extends HttpServlet {
     @Inject
     private OrderService orderService;
     
+    @Resource
+    private ManagedExecutorService executor;
+
      // <editor-fold defaultstate="collapsed" desc="HttpServlet methods. Click on the + sign on the left to edit the code.">
     /**
      * Handles the HTTP <code>GET</code> method.
@@ -94,7 +100,7 @@ public class OrderServlet extends HttpServlet {
                         order.setItemCd(itemCd);
                         order.setToken(token.toString());
                         return orderService.register(order);
-                    }));
+                    }, executor));
                 } else {
                     throw new ServletException("トークンが一致しません");                    
                 }


### PR DESCRIPTION
Java EEではデータソースやトランザクションといった外部リソースを扱う場合にスレッドに関連付けて管理されます。
ですのでカジュアルにスレッドを生成しない方が良いです。
Java EE 7からはConcurrency Utilities for Java EEが入ったのでアプリケーションサーバが管理するスレッドを扱う事ができます。

CompletableFutureの各メソッドは実行するExecutorを指定する事が出来ます。
今回はアプリケーションサーバ管理のスレッドを扱うManagedExecutorServiceをサーブレットにインジェクションし、CompletableFutureに渡すようにしました。

また、 #1 でPayara Microでの起動を行うプルリクエストをしましたが、この場合はPayara Microがデフォルトで持っているManagedExecutorServiceが使われます。
(ユーザー定義のManagedExecutorServiceを使う場合は@ ResourceにJNDI名を指定します)