### PR TITLE
テストコードを修正

### DIFF
--- a/file-comment-plugin/pom.xml
+++ b/file-comment-plugin/pom.xml
@@ -22,18 +22,18 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
-      <version>2.0</version>
+      <version>3.3.9</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>
       <artifactId>maven-plugin-annotations</artifactId>
-      <version>3.2</version>
+      <version>3.4</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-utils</artifactId>
-      <version>3.0.8</version>
+      <version>3.0.22</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
@@ -45,6 +45,18 @@
       <groupId>org.apache.maven.plugin-testing</groupId>
       <artifactId>maven-plugin-testing-harness</artifactId>
       <version>3.3.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-core</artifactId>
+      <version>3.3.9</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-compat</artifactId>
+      <version>3.3.9</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/file-comment-plugin/src/test/java/com/syobochim/FileCommentMojoTest.java
+++ b/file-comment-plugin/src/test/java/com/syobochim/FileCommentMojoTest.java
@@ -1,18 +1,24 @@
 package com.syobochim;
 
-import org.apache.maven.plugin.Mojo;
-import org.apache.maven.plugin.testing.MojoRule;
-import org.apache.maven.plugin.testing.resources.TestResources;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.*;
 
 import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.maven.plugin.testing.MojoRule;
+import org.apache.maven.plugin.testing.resources.TestResources;
+import org.junit.Rule;
+import org.junit.Test;
 
 /**
  * @author syobochim
  */
-@Ignore
 public class FileCommentMojoTest {
 
     @Rule
@@ -23,11 +29,17 @@ public class FileCommentMojoTest {
 
     @Test
     public void ファイルコメントをつける() throws Exception {
-        File baseDir = resources.getBasedir("projects");
-        File pom = new File(baseDir, "pom.xml");
+        File baseDir = resources.getBasedir("java-se-seven-and-eight");
+        mojoRule.executeMojo(baseDir, "addComment");
 
-        Mojo mojo = mojoRule.lookupMojo("addComment", pom);
-        mojo.execute();
+        Path sampleJava = baseDir.toPath().resolve(Paths.get("src", "main", "java", "com",
+                "syobochim", "lambda", "LambdaSample.java"));
+        List<String> comment = Files.readAllLines(sampleJava).stream().limit(3)
+                .collect(Collectors.toList());
+
+        List<String> expected = Arrays.asList("/*", " * syobochim", " */");
+
+        assertThat(comment, is(expected));
     }
 
 }

--- a/file-comment-plugin/src/test/projects/java-se-seven-and-eight/pom.xml
+++ b/file-comment-plugin/src/test/projects/java-se-seven-and-eight/pom.xml
@@ -39,6 +39,7 @@
         <version>1.0-SNAPSHOT</version>
         <configuration>
           <inputDir>src/main/java</inputDir>
+          <comment>syobochim</comment>
 <!--          <comment>これはしょぼちむのプロジェクトだよ</comment>-->
         </configuration>
       </plugin>


### PR DESCRIPTION
まず、そのままテストを実行すると次の例外が出ました。

```
java.lang.NoClassDefFoundError: org/apache/maven/execution/MavenExecutionRequest
```

ググってみると`MavenExecutionRequest`は`maven-core`に入っているようだったので次の`dependency`要素を追加しました、

``` xml
<dependency>
  <groupId>org.apache.maven</groupId>
  <artifactId>maven-core</artifactId>
  <version>3.3.9</version>
  <scope>test</scope>
</dependency>
```

再びテストを実行してみると今度は次の例外が出ました。

```
java.lang.NoSuchMethodError: org.apache.maven.artifact.versioning.DefaultArtifactVersion.compareTo(Lorg/apache/maven/artifact/versioning/ArtifactVersion;)I
```

どうやら`DefaultArtifactVersion`の`compareTo`メソッドの引数の型は元々は`java.lang.Object`だったようですが、下記のコミットから`org.apache.maven.artifact.versioning.ArtifactVersion`に変更されたようです。
- https://github.com/apache/maven/commit/a78ef2d82649f437aed6b93fa40f772463423cb9#diff-eb7ef9d260ecc2e974b49e5bd814925a

このコミットが入っているのは`3.0.2`からのようなのでライブラリのバージョンを上げることにしました。

パッケージ名と`mvn dependency:tree`の結果(下記に抜粋)を元に`maven-plugin-api`のバージョンを上げれば良さそうだと推測しました。
(ついでに他のライブラリもバージョンを上げました)

```
[INFO] +- org.apache.maven:maven-plugin-api:jar:3.3.9:compile
[INFO] |  +- org.apache.maven:maven-artifact:jar:3.3.9:compile
```

この状態でテストを実行すると次の例外が出ました。

```
org.codehaus.plexus.component.repository.exception.ComponentLookupException: java.util.NoSuchElementException
      role: org.apache.maven.repository.RepositorySystem
  roleHint:
```

ググってみるとstackoverflowがヒットしました。
- http://stackoverflow.com/questions/15779351/component-lookup-exception-with-org-apache-maven-repository-repositorysystem-in

これを参考にして次の`dependency`要素を追加しました。

``` xml
<dependency>
  <groupId>org.apache.maven</groupId>
  <artifactId>maven-compat</artifactId>
  <version>3.3.9</version>
  <scope>test</scope>
</dependency>
```

以上の修正をして、ようやくテストを正常に実行できました！

それからテストコードを少しいじって`assertion`を追加しました。
